### PR TITLE
Anpassung der deutschen Ausgabe der Wochentage

### DIFF
--- a/site/snippets/termine.php
+++ b/site/snippets/termine.php
@@ -1,7 +1,7 @@
 <div class="container pt-2 pb-2">
   <?php
     // setlocale(LC_TIME, "de_DE");
-    setlocale(LC_TIME, 'de_DE@euro', 'de_DE', 'de', 'ge');
+    setlocale(LC_TIME, 'de_DE@euro', 'de_DE.utf8', 'de_DE', 'de', 'ge');
     $rand = html(Str::random(4))
   ?>
 


### PR DESCRIPTION
Auf dem aktuellen Webhost für gcv1962.de ist nur 'de_DE.utf8' installiert. Damit die deutsche Ausgabe der Wochentage funktioniert musste dies nun nachgetragen werden.